### PR TITLE
Added Vue3 note-taking chrome extension demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ A curated list of awesome things related to Vue 3
 - [vite-vue3-tailwind-starter](https://github.com/web2033/vite-vue3-tailwind-starter) - Starter Template based on Vite (Vue 3, Vue Router and Tailwind CSS)
 - [vite-wind](https://github.com/boussadjra/vite-wind) -  Boilerplate with Tailwind CSS, TypeScript, css-pro-layout, 9+ components and dark mode support.
 - [Materio-vuetify-vuejs-admin-template-free](https://github.com/themeselection/materio-vuetify-vuejs-admin-template-free) - A Production ready, carefully crafted, most comprehensive Vuetify Vuejs admin template. 
+- [vue3-vite2-chrome-extension-demo](https://github.com/betterRunner/context-note) - A note-taking chrome extension built by Vue3 & Vite2.
 
 ## Tools
 


### PR DESCRIPTION
A 📝note-taking chrome extension built by Vue3 & Vite2. 
Some third libraries such as [VueQuill](https://vueup.github.io/vue-quill/api/events.html#editorchange) and [element-plus](https://element-plus.gitee.io/zh-CN/) are working fine in this demo. Building the chrome extension package by Vite2 is also without a problem.

repo: https://github.com/betterRunner/context-note

Features:
📝 Notebook, reviewing notes on a book, while jumping back to the context for details.
🏷️ Tagbook, manage the notes neatly with a handy tag system.
⌨️ Rich text editor: embed quill as the rich text editor.