### PR TITLE
change vue official document addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ A curated list of awesome things related to Vue 3
 
 ## Official
 
-- [Official Documentation](https://v3.vuejs.org/)
-- [Vue Composition API](https://v3.vuejs.org/guide/introduction.html)
+- [Official Documentation](https://vuejs.org/)
+- [Vue Composition API](https://vuejs.org/guide/introduction.html)
 - [RFCs for substantial changes / feature additions to Vue core](https://github.com/vuejs/rfcs)
 
 ## Related awesome lists


### PR DESCRIPTION
Vue 3 is now the official version, so the documentation website changed to this version. I tried to fix the links to the documentation.